### PR TITLE
Add ability to set provider endpoint suffix. Needed for Azure Government

### DIFF
--- a/Source-v4/BinaryStorageOptions/Azure.Storage/BlobStorageHelper.cs
+++ b/Source-v4/BinaryStorageOptions/Azure.Storage/BlobStorageHelper.cs
@@ -10,11 +10,11 @@ namespace Azure.Storage
 {
 	public class BlobStorageHelper : StorageHelper
 	{
-		private const string blobStorageUriTemplate = "https://{0}.blob.core.windows.net/";
-		private const string blobStorageSecondaryUriTemplate = "https://{0}-secondary.blob.core.windows.net/";
+		private const string blobStorageUriTemplate = "https://{0}.blob.{1}/";
+		private const string blobStorageSecondaryUriTemplate = "https://{0}-secondary.blob.{1}/";
 
-		public BlobStorageHelper(string account, string key) :
-			base(blobStorageUriTemplate, blobStorageSecondaryUriTemplate, account, key)
+		public BlobStorageHelper(string account, string endpointSuffix, string key) :
+			base(blobStorageUriTemplate, blobStorageSecondaryUriTemplate, account, endpointSuffix, key)
 		{
 		}
 

--- a/Source-v4/BinaryStorageOptions/Azure.Storage/FileStorageHelper.cs
+++ b/Source-v4/BinaryStorageOptions/Azure.Storage/FileStorageHelper.cs
@@ -10,12 +10,12 @@ namespace Azure.Storage
 {
 	public class FileStorageHelper : StorageHelper
 	{
-		private const string fileStorageUriTemplate = "https://{0}.file.core.windows.net/";
-		private const string fileStorageSecondaryUriTemplate = "https://{0}-secondary.file.core.windows.net/";
+		private const string fileStorageUriTemplate = "https://{0}.file.{1}/";
+		private const string fileStorageSecondaryUriTemplate = "https://{0}-secondary.file.{1}/";
 		private const int bufferSize = 1024 * 1024 * 4; //File storage max buffer size is 4mb
 
-		public FileStorageHelper(string account, string key) :
-			base(fileStorageUriTemplate, fileStorageSecondaryUriTemplate, account, key)
+		public FileStorageHelper(string account, string endpointSuffix, string key) :
+			base(fileStorageUriTemplate, fileStorageSecondaryUriTemplate, account, endpointSuffix, key)
 		{
 		}
 

--- a/Source-v4/BinaryStorageOptions/Azure.Storage/StorageHelper.cs
+++ b/Source-v4/BinaryStorageOptions/Azure.Storage/StorageHelper.cs
@@ -24,6 +24,7 @@ namespace Azure.Storage
 		private string uriTemplate;
 		private string secondaryUriTemplate;
 		private string account;
+		private string endpointSuffix;
 		private string key;
 		private int retryCounter;
 		private bool isTableStorage;
@@ -37,24 +38,25 @@ namespace Azure.Storage
 			HEAD,
 		}
 
-		public StorageHelper(string uriTemplate, string secondaryUriTemplate, string account, string key, bool isTableStorage = false) 
+		public StorageHelper(string uriTemplate, string secondaryUriTemplate, string account, string endpointSuffix, string key, bool isTableStorage = false) 
 		{
 			this.uriTemplate = uriTemplate;
 			this.secondaryUriTemplate = secondaryUriTemplate;
 			this.account = account;
+			this.endpointSuffix = endpointSuffix;
 			this.key = key;
 			this.isTableStorage = isTableStorage;
 		}
 
-		public StorageHelper(string uriTemplate, string account, string key, bool isTableStorage = false)
-			: this(uriTemplate, null, account, key, isTableStorage)
+		public StorageHelper(string uriTemplate, string account, string endpointSuffix, string key, bool isTableStorage = false)
+			: this(uriTemplate, null, account, endpointSuffix, key, isTableStorage)
 		{
 		}
 
 		protected HttpResponseMessage ExecuteRestRequestWithFailover(HtmlVerb verb, string resourceUri, HttpContent content = null, Dictionary<string, string> additionalHeaders = null)
 		{
 			resourceUri = PreEncodeUrl(resourceUri);
-			Uri fullUri = new Uri(new Uri(string.Format(uriTemplate, account), UriKind.Absolute), new Uri(resourceUri, UriKind.Relative));
+			Uri fullUri = new Uri(new Uri(string.Format(uriTemplate, account, endpointSuffix), UriKind.Absolute), new Uri(resourceUri, UriKind.Relative));
 			try
 			{
 				retryCounter = 0;
@@ -64,7 +66,7 @@ namespace Azure.Storage
 			{
 				if (!string.IsNullOrWhiteSpace(secondaryUriTemplate))
 				{
-					fullUri = new Uri(new Uri(string.Format(secondaryUriTemplate, account), UriKind.Absolute), new Uri(resourceUri, UriKind.Relative));
+					fullUri = new Uri(new Uri(string.Format(secondaryUriTemplate, account, endpointSuffix), UriKind.Absolute), new Uri(resourceUri, UriKind.Relative));
 					retryCounter = 0;
 					return ExecuteRestRequestWithRetry(verb, fullUri, content, additionalHeaders);
 				}
@@ -74,7 +76,7 @@ namespace Azure.Storage
 
 		protected HttpResponseMessage ExecuteRestRequest(HtmlVerb verb, string resourceUri, HttpContent content = null, Dictionary<string, string> additionalHeaders = null)
 		{
-			Uri fullUri = new Uri(new Uri(string.Format(uriTemplate, account), UriKind.Absolute), new Uri(PreEncodeUrl(resourceUri), UriKind.Relative));
+			Uri fullUri = new Uri(new Uri(string.Format(uriTemplate, account, endpointSuffix), UriKind.Absolute), new Uri(PreEncodeUrl(resourceUri), UriKind.Relative));
 			retryCounter = 0;
 			return ExecuteRestRequestWithRetry(verb, fullUri, content, additionalHeaders);
 		}

--- a/Source-v4/BinaryStorageOptions/Azure.Storage/TableStorageHelper.cs
+++ b/Source-v4/BinaryStorageOptions/Azure.Storage/TableStorageHelper.cs
@@ -11,8 +11,8 @@ namespace Azure.Storage
 {
 	public class TableStorageHelper : StorageHelper
 	{
-		private const string tableStorageUriTemplate = "https://{0}.table.core.windows.net/";
-		private const string tableStorageSecondaryUriTemplate = "https://{0}-secondary.table.core.windows.net/";
+		private const string tableStorageUriTemplate = "https://{0}.table.{1}/";
+		private const string tableStorageSecondaryUriTemplate = "https://{0}-secondary.table.{1}/";
 
 		/*
 			{
@@ -29,8 +29,8 @@ namespace Azure.Storage
 		private Regex fileSizeJsonRegex = new Regex(@"""FileSize"":(?<FileSize>\d*)", RegexOptions.Compiled);
 		private Regex queryJsonRegex = new Regex(@"""RowKey"":""(?<RowKey>[a-z0-9-]*)""", RegexOptions.Compiled);
 
-		public TableStorageHelper(string account, string key) :
-			base(tableStorageUriTemplate, tableStorageSecondaryUriTemplate, account, key, true)
+		public TableStorageHelper(string account, string endpointSuffix, string key) :
+			base(tableStorageUriTemplate, tableStorageSecondaryUriTemplate, account, endpointSuffix, key, true)
 		{
 		}
 

--- a/Source-v4/BinaryStorageOptions/Configuration/AzureBlobStorageConfiguration.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/AzureBlobStorageConfiguration.cs
@@ -10,12 +10,20 @@
 			this.configurationProvider = configurationProvider;
 			this.entityType = entityType;
 		}
-
+		
 		public string StorageAccount
 		{
 			get
 			{
 				return configurationProvider.GetSettingValue("StorageAccount");
+			}
+		}
+
+		public string EndpointSuffix
+		{
+			get
+			{
+				return configurationProvider.StorageProviderEndpointSuffix;
 			}
 		}
 

--- a/Source-v4/BinaryStorageOptions/Configuration/AzureFileStorageConfiguration.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/AzureFileStorageConfiguration.cs
@@ -19,6 +19,14 @@
 			}
 		}
 
+		public string EndpointSuffix
+		{
+			get
+			{
+				return configurationProvider.StorageProviderEndpointSuffix;
+			}
+		}
+
 		public string StorageKey
 		{
 			get

--- a/Source-v4/BinaryStorageOptions/Configuration/BaseConfigurationProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/BaseConfigurationProvider.cs
@@ -12,7 +12,9 @@ namespace BinaryStorageOptions.Configuration
 	public class BaseConfigurationProvider
 	{
 		private const int DefaultMaxFileSize = 1024 * 1024 * 5; //Default CRM value
+		private const string DefaultProviderEndpointSuffix = "core.windows.net";
 		protected const string ProviderTypeKey = "Provider Type";
+		protected const string ProviderEndpointSuffix = "ProviderEndpointSuffix";
 		protected const string CompressionTypeKey = "Compression";
 		protected const string EncryptionTypeKey = "Encryption";
 		protected IOrganizationService organizationService;
@@ -47,6 +49,11 @@ namespace BinaryStorageOptions.Configuration
 			{
 			}
 			return providerType;
+		}
+
+		protected string GetStorageProviderEndpointSuffix(string storageProviderEndpointSuffix) 
+		{
+			return string.IsNullOrWhiteSpace(storageProviderEndpointSuffix) ? DefaultProviderEndpointSuffix : storageProviderEndpointSuffix;
 		}
 
 		protected CompressionProviderType GetCompressionProviderType(string compressionProviderValue)
@@ -93,7 +100,7 @@ namespace BinaryStorageOptions.Configuration
 				}
 				return maxFileSize.Value;
 			}
-		}
+		}	
 
 		private int GetAttachmentSizeLimit()
 		{

--- a/Source-v4/BinaryStorageOptions/Configuration/IConfigurationProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/IConfigurationProvider.cs
@@ -6,6 +6,7 @@ namespace BinaryStorageOptions.Configuration
 	{
 		IConfiguration Configuration { get; }
 		StorageProviderType StorageProviderType { get; }
+		string StorageProviderEndpointSuffix { get; }
 		CompressionProviderType CompressionProviderType { get; }
 		EncryptionProviderType EncryptionProviderType { get; }
 		string GetSettingValue(string key);

--- a/Source-v4/BinaryStorageOptions/Configuration/PluginStepConfigurationProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/PluginStepConfigurationProvider.cs
@@ -37,6 +37,15 @@ namespace BinaryStorageOptions.Configuration
 			}
 		}
 
+		public string StorageProviderEndpointSuffix 
+		{
+            get
+            {
+				return GetStorageProviderEndpointSuffix(GetSettingValue(ProviderEndpointSuffix));
+
+			}
+		}
+
 		public CompressionProviderType CompressionProviderType
 		{
 			get

--- a/Source-v4/BinaryStorageOptions/Providers/AzureBlobStorageProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Providers/AzureBlobStorageProvider.cs
@@ -16,7 +16,7 @@ namespace BinaryStorageOptions.Providers
 		public AzureBlobStorageProvider(AzureBlobStorageConfiguration configuration)
 		{
 			this.configuration = configuration;
-			blobStorageHelper = new BlobStorageHelper(configuration.StorageAccount, configuration.StorageKey);
+			blobStorageHelper = new BlobStorageHelper(configuration.StorageAccount, configuration.EndpointSuffix, configuration.StorageKey);
 		}
 
 		public List<string> GetFileNames()

--- a/Source-v4/BinaryStorageOptions/Providers/AzureFileStorageProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Providers/AzureFileStorageProvider.cs
@@ -16,7 +16,7 @@ namespace BinaryStorageOptions.Providers
 		public AzureFileStorageProvider(AzureFileStorageConfiguration configuration)
 		{
 			this.configuration = configuration;
-			fileStorageHelper = new FileStorageHelper(configuration.StorageAccount, configuration.StorageKey);
+			fileStorageHelper = new FileStorageHelper(configuration.StorageAccount, configuration.EndpointSuffix, configuration.StorageKey);
 		}
 
 		public List<string> GetFileNames()

--- a/Source-v4/BinaryStorageOptions/UnsecureConfigExample.xml
+++ b/Source-v4/BinaryStorageOptions/UnsecureConfigExample.xml
@@ -3,6 +3,11 @@
 	<Setting key="ConfigurationProviderType" value="PluginStepConfigurationProvider"/>
 	<!-- Valid values are defined in StorageProviderType enum. -->
 	<Setting key="Provider Type" value="AzureFile" />
+	<!-- Optional endpoint suffix. No leading . or trailing /
+		 For commercial Azure leave empty of use core.windows.net
+		 and for Azure Government use core.usgovcloudapi.net	
+	-->
+	<Setting key="ProviderEndpointSuffix" value="core.windows.net" />
 	<!-- 
 		Valid values are defined in CompressionProviderType enum.  
 		Defaults to "PassThrough" if it doesn't exist 


### PR DESCRIPTION
Added a new optional configuration value called ProviderEndpointSuffix in the unsecured configuration.  The value will allow the user to override the default value of 'core.windows.net'.  This is needed because Azure Government utilizes 'core.usgovcloudapi.net'.

Reference(s):
https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-get-started-connect-to-storage