### PR TITLE
Add option to use SAS Token for authentication to service instead of Access Key

### DIFF
--- a/Source-v4/BinaryStorageOptions/Azure.Storage/BlobStorageHelper.cs
+++ b/Source-v4/BinaryStorageOptions/Azure.Storage/BlobStorageHelper.cs
@@ -13,8 +13,8 @@ namespace Azure.Storage
 		private const string blobStorageUriTemplate = "https://{0}.blob.{1}/";
 		private const string blobStorageSecondaryUriTemplate = "https://{0}-secondary.blob.{1}/";
 
-		public BlobStorageHelper(string account, string endpointSuffix, string key) :
-			base(blobStorageUriTemplate, blobStorageSecondaryUriTemplate, account, endpointSuffix, key)
+		public BlobStorageHelper(string account, string endpointSuffix, string key, bool isSasToken) :
+			base(blobStorageUriTemplate, blobStorageSecondaryUriTemplate, account, endpointSuffix, key, isSasToken)
 		{
 		}
 

--- a/Source-v4/BinaryStorageOptions/Azure.Storage/FileStorageHelper.cs
+++ b/Source-v4/BinaryStorageOptions/Azure.Storage/FileStorageHelper.cs
@@ -14,8 +14,8 @@ namespace Azure.Storage
 		private const string fileStorageSecondaryUriTemplate = "https://{0}-secondary.file.{1}/";
 		private const int bufferSize = 1024 * 1024 * 4; //File storage max buffer size is 4mb
 
-		public FileStorageHelper(string account, string endpointSuffix, string key) :
-			base(fileStorageUriTemplate, fileStorageSecondaryUriTemplate, account, endpointSuffix, key)
+		public FileStorageHelper(string account, string endpointSuffix, string key, bool isSasToken) :
+			base(fileStorageUriTemplate, fileStorageSecondaryUriTemplate, account, endpointSuffix, key, isSasToken)
 		{
 		}
 

--- a/Source-v4/BinaryStorageOptions/Azure.Storage/TableStorageHelper.cs
+++ b/Source-v4/BinaryStorageOptions/Azure.Storage/TableStorageHelper.cs
@@ -29,8 +29,8 @@ namespace Azure.Storage
 		private Regex fileSizeJsonRegex = new Regex(@"""FileSize"":(?<FileSize>\d*)", RegexOptions.Compiled);
 		private Regex queryJsonRegex = new Regex(@"""RowKey"":""(?<RowKey>[a-z0-9-]*)""", RegexOptions.Compiled);
 
-		public TableStorageHelper(string account, string endpointSuffix, string key) :
-			base(tableStorageUriTemplate, tableStorageSecondaryUriTemplate, account, endpointSuffix, key, true)
+		public TableStorageHelper(string account, string endpointSuffix, string key, bool isSasToken) :
+			base(tableStorageUriTemplate, tableStorageSecondaryUriTemplate, account, endpointSuffix, key, isSasToken, true)
 		{
 		}
 

--- a/Source-v4/BinaryStorageOptions/BinaryStorageOptions.csproj
+++ b/Source-v4/BinaryStorageOptions/BinaryStorageOptions.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\AESEncryptionProvider.cs" />
+    <Compile Include="Providers\AuthenticationType.cs" />
     <Compile Include="Providers\AzureFileStorageProvider.cs" />
     <Compile Include="Providers\AzureBlobStorageProvider.cs" />
     <Compile Include="Providers\BinaryStorageProvider.cs" />

--- a/Source-v4/BinaryStorageOptions/Configuration/AzureBlobStorageConfiguration.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/AzureBlobStorageConfiguration.cs
@@ -34,6 +34,14 @@
 				return configurationProvider.GetSettingValue("StorageKey");
 			}
 		}
+		
+		public bool IsSasToken
+		{
+			get
+			{
+				return configurationProvider.AuthenticationType == Providers.AuthenticationType.SASToken;
+			}
+		}
 
 		public string Container
 		{

--- a/Source-v4/BinaryStorageOptions/Configuration/AzureFileStorageConfiguration.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/AzureFileStorageConfiguration.cs
@@ -35,6 +35,14 @@
 			}
 		}
 
+		public bool IsSasToken
+        {
+			get
+            {
+				return configurationProvider.AuthenticationType == Providers.AuthenticationType.SASToken;
+            }
+        }
+
 		public string Share
 		{
 			get

--- a/Source-v4/BinaryStorageOptions/Configuration/BaseConfigurationProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/BaseConfigurationProvider.cs
@@ -17,6 +17,7 @@ namespace BinaryStorageOptions.Configuration
 		protected const string ProviderEndpointSuffix = "ProviderEndpointSuffix";
 		protected const string CompressionTypeKey = "Compression";
 		protected const string EncryptionTypeKey = "Encryption";
+		protected const string AuthenticationTypeKey = "AuthenticationType";
 		protected IOrganizationService organizationService;
 		protected string configurationForEntityType;
 
@@ -54,6 +55,19 @@ namespace BinaryStorageOptions.Configuration
 		protected string GetStorageProviderEndpointSuffix(string storageProviderEndpointSuffix) 
 		{
 			return string.IsNullOrWhiteSpace(storageProviderEndpointSuffix) ? DefaultProviderEndpointSuffix : storageProviderEndpointSuffix;
+		}
+		
+		protected AuthenticationType GetAuthenticationType(string authenticationTypeValue)
+		{
+			AuthenticationType authenticationType = Providers.AuthenticationType.AccessKey;
+			try
+			{
+				authenticationType = (AuthenticationType)Enum.Parse(typeof(AuthenticationType), authenticationTypeValue);
+			}
+			catch
+			{
+			}
+			return authenticationType;
 		}
 
 		protected CompressionProviderType GetCompressionProviderType(string compressionProviderValue)

--- a/Source-v4/BinaryStorageOptions/Configuration/IConfigurationProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/IConfigurationProvider.cs
@@ -7,6 +7,7 @@ namespace BinaryStorageOptions.Configuration
 		IConfiguration Configuration { get; }
 		StorageProviderType StorageProviderType { get; }
 		string StorageProviderEndpointSuffix { get; }
+		AuthenticationType AuthenticationType { get; }
 		CompressionProviderType CompressionProviderType { get; }
 		EncryptionProviderType EncryptionProviderType { get; }
 		string GetSettingValue(string key);

--- a/Source-v4/BinaryStorageOptions/Configuration/PluginStepConfigurationProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Configuration/PluginStepConfigurationProvider.cs
@@ -17,8 +17,8 @@ namespace BinaryStorageOptions.Configuration
 		public PluginStepConfigurationProvider(IOrganizationService organizationService, string configurationForEntityType, string unsecurePluginStepConfiguration, string securePluginStepConfiguration) :
 			base(organizationService, configurationForEntityType)
 		{
-			unsecureDocument = XDocument.Parse(unsecurePluginStepConfiguration);
-			secureDocument = XDocument.Parse(securePluginStepConfiguration);
+			unsecureDocument = XDocument.Parse(unsecurePluginStepConfiguration.Replace("&", "&amp;"));
+			secureDocument = XDocument.Parse(securePluginStepConfiguration.Replace("&", "&amp;"));
 		}
 
 		public IConfiguration Configuration
@@ -36,6 +36,14 @@ namespace BinaryStorageOptions.Configuration
 				return GetStorageProviderType(GetSettingValue(ProviderTypeKey));
 			}
 		}
+
+		public AuthenticationType AuthenticationType
+        {
+			get
+            {
+				return GetAuthenticationType(GetSettingValue(AuthenticationTypeKey));
+            }
+        }
 
 		public string StorageProviderEndpointSuffix 
 		{
@@ -73,7 +81,7 @@ namespace BinaryStorageOptions.Configuration
 			{
 				return null;
 			}
-			return setting.Attribute("value").Value;
+			return setting.Attribute("value").Value.Replace("&amp;", "&");
 		}
 	}
 }

--- a/Source-v4/BinaryStorageOptions/Providers/AuthenticationType.cs
+++ b/Source-v4/BinaryStorageOptions/Providers/AuthenticationType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BinaryStorageOptions.Providers
+{
+	public enum AuthenticationType
+	{
+		AccessKey = 0,
+		SASToken = 1
+	}
+}

--- a/Source-v4/BinaryStorageOptions/Providers/AzureBlobStorageProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Providers/AzureBlobStorageProvider.cs
@@ -16,7 +16,7 @@ namespace BinaryStorageOptions.Providers
 		public AzureBlobStorageProvider(AzureBlobStorageConfiguration configuration)
 		{
 			this.configuration = configuration;
-			blobStorageHelper = new BlobStorageHelper(configuration.StorageAccount, configuration.EndpointSuffix, configuration.StorageKey);
+			blobStorageHelper = new BlobStorageHelper(configuration.StorageAccount, configuration.EndpointSuffix, configuration.StorageKey, configuration.IsSasToken);
 		}
 
 		public List<string> GetFileNames()

--- a/Source-v4/BinaryStorageOptions/Providers/AzureFileStorageProvider.cs
+++ b/Source-v4/BinaryStorageOptions/Providers/AzureFileStorageProvider.cs
@@ -16,7 +16,7 @@ namespace BinaryStorageOptions.Providers
 		public AzureFileStorageProvider(AzureFileStorageConfiguration configuration)
 		{
 			this.configuration = configuration;
-			fileStorageHelper = new FileStorageHelper(configuration.StorageAccount, configuration.EndpointSuffix, configuration.StorageKey);
+			fileStorageHelper = new FileStorageHelper(configuration.StorageAccount, configuration.EndpointSuffix, configuration.StorageKey, configuration.IsSasToken);
 		}
 
 		public List<string> GetFileNames()

--- a/Source-v4/BinaryStorageOptions/UnsecureConfigExample.xml
+++ b/Source-v4/BinaryStorageOptions/UnsecureConfigExample.xml
@@ -25,6 +25,11 @@
 		Valid values are defined in EncryptionProviderType enum.  
 		Defaults to "PassThrough" if it doesn't exist 
 	-->
+	<Setting key="AuthenticationType" value="AccessKey" />
+	<!--
+		Valid values are defined in AuthenticationType enum.
+		Defaults to "AccessKey" if it doesn't exist
+	-->
 	<Setting key="Encryption" value="PassThrough" />
 	<!-- 
 		Valid values are defined in System.IO.Compression.CompressionLevel 


### PR DESCRIPTION
Allows the use of a storage account level SAS Token for authentication instead of using the Access Key. This may be desirable for security concerns. 